### PR TITLE
Feature: Allow configuration of cache file

### DIFF
--- a/taskrunner.el
+++ b/taskrunner.el
@@ -106,6 +106,12 @@
   :group 'taskrunner
   :type 'string)
 
+(defcustom taskrunner-cache-file
+  (expand-file-name "taskrunner-tasks.eld" user-emacs-directory)
+  "Location of the taskrunner cache file."
+  :group 'taskrunner
+  :type 'string)
+
 (defvar taskrunner--cache-file-read nil
   "Indicates whether or not the cache file has been read.
 Do not edit unless you want to reread the cache.")

--- a/taskrunner.el
+++ b/taskrunner.el
@@ -300,41 +300,40 @@ If NO-OVERWRITE is non-nil then do not overwrite the cache file."
 (defun taskrunner-read-cache-file ()
   "Read the task cache file and initialize the task caches with its contents."
   (with-temp-buffer
-    (let ((taskrunner-cache-filepath (expand-file-name "taskrunner-tasks.eld" user-emacs-directory))
-          (file-tasks))
-      (when (file-exists-p taskrunner-cache-filepath)
+    (if (file-exists-p taskrunner-cache-file)
         (with-temp-buffer
-          (insert-file-contents taskrunner-cache-filepath)
-          (setq file-tasks (car (read-from-string (buffer-string))))
-          ;; Load all the caches with the retrieved info
-          (setq taskrunner-tasks-cache (nth 0 file-tasks))
-          (setq taskrunner-last-command-cache(nth 1 file-tasks))
-          (setq taskrunner-build-cache (nth 2 file-tasks))
-          (setq taskrunner-command-history-cache (nth 3 file-tasks))
-          ;; Length is checked for backwards compatibility.  The cache file will
-          ;; be overwritten soon but if the user installed this package before
-          ;; the new cache was added, trying to read in the new command cache
-          ;; will throw an error
-          (when (= (length file-tasks) 5)
-            (setq taskrunner-custom-command-cache (nth 4 file-tasks))))))))
+          (insert-file-contents taskrunner-cache-file)
+          (let ((file-tasks (car (read-from-string (buffer-string)))))
+            ;; Load all the caches with the retrieved info
+            (setq taskrunner-tasks-cache (nth 0 file-tasks))
+            (setq taskrunner-last-command-cache(nth 1 file-tasks))
+            (setq taskrunner-build-cache (nth 2 file-tasks))
+            (setq taskrunner-command-history-cache (nth 3 file-tasks))
+            ;; Length is checked for backwards compatibility.  The cache file will
+            ;; be overwritten soon but if the user installed this package before
+            ;; the new cache was added, trying to read in the new command cache
+            ;; will throw an error
+            (when (= (length file-tasks) 5)
+              (setq taskrunner-custom-command-cache (nth 4 file-tasks))))))))
 
 (defun taskrunner-write-cache-file ()
   "Save all tasks in the cache to the cache file in Emacs user directory."
-  (let ((taskrunner-cache-filepath (expand-file-name "taskrunner-tasks.eld" user-emacs-directory)))
-    (write-region (format "%s%s\n" taskrunner--cache-file-header-warning
-                          (list (prin1-to-string taskrunner-tasks-cache)
-                                (prin1-to-string taskrunner-last-command-cache)
-                                (prin1-to-string taskrunner-build-cache)
-                                (prin1-to-string taskrunner-command-history-cache)
-                                (prin1-to-string taskrunner-custom-command-cache)))
-                  nil
-                  taskrunner-cache-filepath)))
+  (unless (file-exists-p taskrunner-cache-file)
+    (mkdir (file-name-directory taskrunner-cache-file) t))
+  (write-region (format "%s%s\n" taskrunner--cache-file-header-warning
+                        (list (prin1-to-string taskrunner-tasks-cache)
+                              (prin1-to-string taskrunner-last-command-cache)
+                              (prin1-to-string taskrunner-build-cache)
+                              (prin1-to-string taskrunner-command-history-cache)
+                              (prin1-to-string taskrunner-custom-command-cache)))
+                nil
+                taskrunner-cache-file))
 
 (defun taskrunner-delete-cache-file ()
   "Delete the cache file used for persistence between Emacs sessions.
 The user will be asked to confirm this action before deleting the file."
   (if (y-or-n-p "Are you sure you want to delete the cache file? ")
-      (delete-file (expand-file-name "taskrunner-tasks.eld" user-emacs-directory))))
+      (delete-file taskrunner-cache-file)))
 
 ;; Functions/Macros related to finding files which signal what type of build
 ;; system/taskrunner is used


### PR DESCRIPTION
It is pretty common for Emacs packages to have customizable paths for their cache/configuration files, so the user can choose a location that suits them. This PR adds that feature to `taskrunner`. Maybe you would also be interested in adding your package to [no-littering](https://github.com/emacscollective/no-littering).