### PR TITLE
Add support for clojure-cli

### DIFF
--- a/README.org
+++ b/README.org
@@ -38,6 +38,7 @@ It can be used for the following systems/frontends listed below.
 - [X] Jake
 - [X] Apache ant
 - [X] mix
+- [X] clojure-cli
 - [X] leinengen
 - [X] rake
 - [X] Make

--- a/taskrunner-clojure-cli.el
+++ b/taskrunner-clojure-cli.el
@@ -1,0 +1,75 @@
+;;; taskrunner-clojure-cli.el --- Provide functions to retrieve clojure tasks via Clojure's cli -*- lexical-binding: t; -*-
+;; Copyright (C) 2019 Yavor Konstantinov
+
+;;;; Commentary:
+;; Provide support for Clojure(deps.edn)
+
+;;;; Code:
+
+;;;; Requirements
+(require 'cl-lib)
+
+;;;; Variables
+
+(defconst taskrunner-clojure-cli--query
+  "(require '[clojure.tools.deps] '[clojure.string] '[clojure.set])
+(let [edn-srcs (clojure.tools.deps/create-edn-maps nil)
+      src-aliases (reduce-kv #(assoc %1 %2 (:aliases %3)) {} edn-srcs)]
+  (doseq [[prefix target] [[\"-X\" :exec-fn]
+                           [\"-M\" :main-opts]]]
+    (let [invokable-aliases (reduce-kv
+                             (fn [m src aliases]
+                               (assoc m
+                                      src
+                                      (reduce-kv
+                                       (fn [a alias alias-defn]
+                                         (cond-> a
+                                           (pos? (count (clojure.set/intersection #{target} (set (keys alias-defn)))))
+                                           (assoc alias alias-defn)))
+                                       {} aliases)))
+                             {} src-aliases)
+          all-aliases (->> invokable-aliases (map val) (mapcat #(-> % keys sort)) distinct)]
+      (doseq [alias all-aliases]
+        (let [srcs (reduce-kv (fn [srcs src deps-edn]
+                                (if (contains? (:aliases deps-edn) alias)
+                                  (conj srcs src)
+                                  srcs))
+                              [] edn-srcs)]
+          (println (str \"(\" (clojure.string/join \", \" (map name srcs)) \")\") (str prefix alias)))))))"
+  "Clojure snippet used to retrieve scoped aliases")
+
+;;;; Functions
+
+;; These are here just to silence the bytecompiler. They are defined in
+;; `taskrunner.el' and will be loaded later on but due to these files being
+;; required before the function being loaded, a warning is emitted.
+
+(declare-function taskrunner--make-task-buff-name "ext:taskrunner")
+
+(defun taskrunner-clojure-cli--get-tasks-from-buffer ()
+  "Retrieve all clojure-cli tasks from the current buffer."
+  (remove nil
+          (cl-map 'list (lambda (elem)
+                          (when (string-prefix-p "(" elem)
+                            (concat "CLOJURE " elem)))
+                  (split-string (buffer-string) "\n"))))
+
+(defun taskrunner-get-clojure-cli-tasks (DIR)
+  "Retrieve the tasks for the project in directory DIR.
+This function returns a list of the form:
+\(\"CLOJURE TASK1\" \"CLOJURE TASK2\"...)"
+  (let ((default-directory DIR)
+        (task-buffer (taskrunner--make-task-buff-name "clojure-cli"))
+        (clojure-tasks))
+
+    (call-process "clojure" nil task-buffer nil
+                  "-M" "-e" taskrunner-clojure-cli--query)
+    (with-temp-buffer
+      (set-buffer task-buffer)
+      (goto-char (point-min))
+      (setq clojure-tasks (taskrunner-clojure-cli--get-tasks-from-buffer))
+      (kill-current-buffer)
+      clojure-tasks)))
+
+(provide 'taskrunner-clojure-cli)
+;;; taskrunner-clojure-cli.el ends here

--- a/taskrunner.el
+++ b/taskrunner.el
@@ -90,6 +90,7 @@
 (require 'taskrunner-ruby)
 (require 'taskrunner-static-targets)
 (require 'taskrunner-mix)
+(require 'taskrunner-clojure-cli)
 (require 'taskrunner-leiningen)
 (require 'taskrunner-general)
 
@@ -421,6 +422,9 @@ to a single file."
     (if (member "mix.exs" proj-root-files)
         (push (list 'MIX (expand-file-name "mix.exs" DIR)) files))
 
+    (if (member "deps.edn" proj-root-files)
+        (push (list 'CLOJURE-CLI (expand-file-name "deps.edn" DIR)) files))
+
     (if (member "project.clj" proj-root-files)
         (push (list 'LEIN (expand-file-name "project.clj" DIR)) files))
 
@@ -530,6 +534,9 @@ updating the cache."
 
     (if (member "mix.exs" work-dir-files)
         (setq tasks (append tasks (taskrunner-get-mix-tasks DIR))))
+
+    (if (member "deps.edn" work-dir-files)
+        (setq tasks (append tasks (taskrunner-get-clojure-cli-tasks DIR))))
 
     (if (member "project.clj" work-dir-files)
         (setq tasks (append tasks (taskrunner-get-leiningen-tasks DIR))))
@@ -818,6 +825,8 @@ from the build cache."
            (setq command (concat "npx" " " taskrunner-program " " task-name)))
           ((string-equal "dobi" taskrunner-program)
            (setq command (concat taskrunner-dobi-bin-name " " task-name)))
+          ((string-equal "clojure" taskrunner-program)
+           (setq command (concat "clojure" " " (string-join (cdr (split-string task-name)) " "))))
           (t
            (setq command (concat taskrunner-program " " task-name))))
 


### PR DESCRIPTION
This adds support for `deps.edn`-defined tasks
* Aliases that contain `:main-opts` are invoked with `-M`
* Aliases that contain `:exec-fn` are invoked with `-X`

Aliases that have parameters are currently being ignored until we find a straightforward way to enumerate the alternatives. 
An example are aliases containing only `:ns-default` - the best-case set of arguments is the set of public functions of that namespace, which may be expensive to calculate.

Thanks for this amazing tool! 
I see it being reinvented/rediscovered at least once a year - I'm glad took the time to write it and share it with us.